### PR TITLE
Permission is added to Manifest

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.doorbell.android"
-    android:versionCode="1"
-    android:versionName="1.0" >
-
+    package="io.doorbell.android" >
+    
+    <uses-permission android:name="android.permission.INTERNET" />
+    
     <uses-sdk
         android:minSdkVersion="3"
         android:targetSdkVersion="18" />


### PR DESCRIPTION
This way Manifest merger will merge the permission. 
Even when the consumer app does not have the permission, it will be added. 

And version code and name are removed. They are not used at all.
