### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: android
+
+jdk:
+ - oraclejdk8
+
+android:
+  components:
+    - platform-tools
+    - tools
+    - build-tools-23.0.2
+#    - android-23 # need to remove Apache deps
+    - android-22
+    - extra-android-support
+    - extra-google-google_play_services
+    - extra-android-m2repository
+    - extra-google-m2repository
+  licenses:
+    - '.+'
+
+script:
+    - ./gradlew clean assemble --stacktrace
+
+notifications:
+  email: false
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.gradle
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
-# Doorbell Android SDK
+# Doorbell Android SDK [![Status](https://travis-ci.org/doorbell/android-sdk.svg?branch=master)](https://travis-ci.org/doorbell/android-sdk)
 
 View full documentation [here](https://doorbell.io/docs/android).
+


### PR DESCRIPTION
For issue: https://github.com/doorbell/android-sdk/issues/7
- Added travis ci badge
- Added travis ci support (will use android 23 when apache deps are removed)
